### PR TITLE
feat: energy flow policy

### DIFF
--- a/configs/agent/base_off_policy.yaml
+++ b/configs/agent/base_off_policy.yaml
@@ -2,7 +2,7 @@
 agent_type: off_policy
 encoder: spatial_temporal
 temporal_model_type: transformer
-policy_type: diffusion
+policy_type: energy_flow
 buffer_size: 20000
 learning_starts: 2000
 detach_actor: 1
@@ -12,5 +12,16 @@ disable_state_predictor: 0
 dacer_loss_weight: 0.05
 denoising_time: 0.9
 denoising_steps: 1
+# EnergyFlow knobs (used when policy_type=energy_flow). The action-value head
+# is reused as a scalar energy E = -Q(s,a,t); its action-gradient is trained
+# by denoising score matching, and probability-flow ODE rollouts on +∇_a Q
+# generate actions (Algorithm 2 of "Recovering Hidden Reward in Diffusion-
+# Based Policies", with α absorbed into Q).
+energy_sigma_min: 0.01
+energy_sigma_max: 1.0
+energy_sigma_t_max: 1.0
+energy_ode_steps: 20
+energy_ode_endpoint: 0.001
+energy_time_embed_dim: 128
 batch_size: 16
 learning_rate: 1e-5

--- a/configs/agent/base_on_policy.yaml
+++ b/configs/agent/base_on_policy.yaml
@@ -3,7 +3,6 @@ agent_type: on_policy
 network_class: actor_critic_with_state_value
 encoder: temporal_only
 temporal_model_type: identity
-policy_type: beta
 batch_size: 16
 learning_rate: 1e-5
 buffer_capacity: 2048

--- a/configs/agent/base_streaming.yaml
+++ b/configs/agent/base_streaming.yaml
@@ -2,7 +2,6 @@
 agent_type: streaming
 encoder: spatial_temporal
 temporal_model_type: transformer
-policy_type: diffusion
 batch_size: 1
 learning_rate: 2e-6
 use_eligibility_trace: 1

--- a/src/vla_streaming_rl/networks/actor_critic_with_action_value.py
+++ b/src/vla_streaming_rl/networks/actor_critic_with_action_value.py
@@ -5,7 +5,10 @@ import torch.nn.functional as F
 from hl_gauss_pytorch import HLGaussLoss
 
 from vla_streaming_rl.networks.backbone import SpatialTemporalEncoder, TemporalOnlyEncoder
-from vla_streaming_rl.networks.diffusion_utils import compute_actor_loss_with_dacer
+from vla_streaming_rl.networks.diffusion_utils import (
+    compute_actor_loss_with_dacer,
+    compute_actor_loss_with_energy_flow,
+)
 from vla_streaming_rl.networks.image_processor import ImageProcessor
 from vla_streaming_rl.networks.policy_head import BetaPolicy, CFGDiffusionPolicy, DiffusionPolicy
 from vla_streaming_rl.networks.prediction_head import StatePredictionHead
@@ -43,6 +46,12 @@ class ActorCriticWithActionValue(nn.Module):
         detach_critic: bool,
         detach_predictor: bool,
         disable_state_predictor: bool,
+        energy_sigma_min: float,
+        energy_sigma_max: float,
+        energy_sigma_t_max: float,
+        energy_ode_steps: int,
+        energy_ode_endpoint: float,
+        energy_time_embed_dim: int,
     ) -> None:
         super().__init__()
         self.gamma = gamma
@@ -114,6 +123,13 @@ class ActorCriticWithActionValue(nn.Module):
                 horizon=horizon,
                 denoising_steps=denoising_steps,
             )
+        elif self.policy_type == "energy_flow":
+            # No separate actor module: the action-value head is reused as a
+            # time-conditioned scalar energy. Action sampling and the actor
+            # loss are routed through self.value_head directly.
+            self.policy_head = None
+        else:
+            raise ValueError(f"Unknown policy_type: {self.policy_type=}")
         self.value_head = ActionValueHead(
             in_channels=self.encoder.output_dim,
             action_dim=self.action_dim,
@@ -122,6 +138,13 @@ class ActorCriticWithActionValue(nn.Module):
             block_num=critic_block_num,
             num_bins=self.num_bins,
             sparsity=sparsity,
+            use_energy_flow=(self.policy_type == "energy_flow"),
+            energy_sigma_min=energy_sigma_min,
+            energy_sigma_max=energy_sigma_max,
+            energy_sigma_t_max=energy_sigma_t_max,
+            energy_ode_steps=energy_ode_steps,
+            energy_ode_endpoint=energy_ode_endpoint,
+            energy_time_embed_dim=energy_time_embed_dim,
         )
         self.prediction_head = StatePredictionHead(
             image_processor=self.image_processor,
@@ -150,6 +173,13 @@ class ActorCriticWithActionValue(nn.Module):
     def init_state(self) -> torch.Tensor:
         return self.encoder.init_state()
 
+    def _sample_action(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Dispatch to the right action sampler based on ``policy_type``."""
+        if self.policy_type == "energy_flow":
+            hl = self.hl_gauss_loss if self.num_bins > 1 else None
+            return self.value_head.get_action(x, hl_gauss_loss=hl)
+        return self.policy_head.get_action(x)
+
     def tokenize_task_prompt(self, task_prompt: str) -> list[int]:
         return []
 
@@ -170,8 +200,8 @@ class ActorCriticWithActionValue(nn.Module):
 
         x, rnn_state = self.encoder(s_seq, obs_z_seq, a_seq, r_seq, rnn_state)  # (B, hidden_dim)
 
-        # Get action chunk from policy_head
-        action, a_logp = self.policy_head.get_action(x)  # (B, horizon, action_dim)
+        # Get action chunk from the active policy (or energy flow head)
+        action, a_logp = self._sample_action(x)  # (B, horizon, action_dim)
 
         # Get action-value from value_head
         q_dict = self.value_head(x, action)
@@ -236,6 +266,10 @@ class ActorCriticWithActionValue(nn.Module):
             actor_loss, actor_activations, actor_info = self._compute_actor_loss_cfgrl(
                 curr_state, action_chunk
             )
+        elif self.policy_type == "energy_flow":
+            actor_loss, actor_activations, actor_info = self._compute_actor_loss_energy_flow(
+                curr_state, action_chunk
+            )
         seq_loss, seq_activations, seq_info = self._compute_sequence_loss(data, curr_state)
 
         total_loss = self.critic_loss_weight * critic_loss + actor_loss + seq_loss
@@ -289,6 +323,10 @@ class ActorCriticWithActionValue(nn.Module):
             actor_loss, actor_activations, actor_info = self._compute_actor_loss_pg(prev_state)
         elif self.policy_type == "cfgrl":
             actor_loss, actor_activations, actor_info = self._compute_actor_loss_cfgrl(
+                prev_state, action_chunk
+            )
+        elif self.policy_type == "energy_flow":
+            actor_loss, actor_activations, actor_info = self._compute_actor_loss_energy_flow(
                 prev_state, action_chunk
             )
         seq_loss, seq_activations, seq_info = self._compute_sequence_loss(data, prev_state)
@@ -356,7 +394,7 @@ class ActorCriticWithActionValue(nn.Module):
         rnn_state: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         state, rnn_state_out = self.encoder.forward(obs, obs_z, actions, rewards, rnn_state)
-        action, _ = self.policy_head.get_action(state)
+        action, _ = self._sample_action(state)
         q_dict = self.value_head(state, action)
         q = q_dict["output"]
         q = self.hl_gauss_loss(q).view(-1) if self.num_bins > 1 else q.view(-1)
@@ -413,6 +451,30 @@ class ActorCriticWithActionValue(nn.Module):
         }
 
         return critic_loss, activations_dict, info_dict
+
+    def _compute_actor_loss_energy_flow(self, curr_state, action_chunk):
+        """Denoising score matching loss on the energy-flow Q head.
+
+        The buffer action chunk plays the role of the expert sample (a_0); we
+        match +∇_a Q(a_t, s, t) against -ε/σ(t) in the σ²-weighted form
+            L = E ||σ(t) · ∇_a Q(a_t, s, t) + ε||²
+        where a_t = a_0 + σ(t)·ε under the geometric VE schedule. This trains
+        the action gradient of Q to be a valid score field of the data
+        distribution, jointly with the standard TD loss that grounds Q at
+        t ≈ 0.
+        """
+        if self.detach_actor:
+            curr_state = curr_state.detach()
+        loss, activations_dict, info_dict = compute_actor_loss_with_energy_flow(
+            curr_state,
+            action_chunk,
+            self.value_head,
+            self.hl_gauss_loss if self.num_bins > 1 else None,
+            self.num_bins,
+        )
+        info_dict["log_pi"] = 0.0
+        info_dict.setdefault("advantage", 0.0)
+        return loss, activations_dict, info_dict
 
     def _compute_actor_loss(self, curr_state):
         """

--- a/src/vla_streaming_rl/networks/build.py
+++ b/src/vla_streaming_rl/networks/build.py
@@ -72,6 +72,12 @@ def build_network(
             detach_critic=args.detach_critic,
             detach_predictor=args.detach_predictor,
             disable_state_predictor=args.disable_state_predictor,
+            energy_sigma_min=args.energy_sigma_min,
+            energy_sigma_max=args.energy_sigma_max,
+            energy_sigma_t_max=args.energy_sigma_t_max,
+            energy_ode_steps=args.energy_ode_steps,
+            energy_ode_endpoint=args.energy_ode_endpoint,
+            energy_time_embed_dim=args.energy_time_embed_dim,
         )
     elif args.network_class == "vlm_actor_critic_with_action_value":
         network = VLMActorCriticWithActionValue(

--- a/src/vla_streaming_rl/networks/diffusion_utils.py
+++ b/src/vla_streaming_rl/networks/diffusion_utils.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 import torch
+from torch import nn
 from torch.nn import functional as F
+
+from .value_head import _vp_sigma
 
 
 def euler_denoise(
@@ -119,3 +122,71 @@ def compute_actor_loss_with_dacer(
     }
 
     return total_loss, advantage_dict, info_dict
+
+
+def compute_actor_loss_with_energy_flow(
+    state: torch.Tensor,
+    action: torch.Tensor,
+    value_head,
+    hl_gauss_loss: nn.Module | None,
+    num_bins: int,
+) -> tuple[torch.Tensor, dict, dict]:
+    """Denoising score matching loss applied to the action-value head used as
+    a scalar energy field (``E = -Q``).
+
+    Following EnergyFlow (Eq. 15 with α = 1), the score of the buffer-action
+    distribution is matched against +∇_a Q at randomly sampled noise levels.
+    With λ(t) = σ²(t), the σ²-weighted DSM objective collapses into
+
+        L = E_{t, a_0, ε} ||σ(t) · ∇_a Q(a_t, s, t) + ε||²,
+
+    where a_t = a_0 + σ(t)·ε with the geometric VE schedule
+    σ(t) = σ_min^(1 - t/T) · σ_max^(t/T). The clean buffer action ``action``
+    serves as a_0 (the role of expert demonstrations in the paper).
+
+    Args:
+        state: (B, state_dim) state embedding.
+        action: (B, horizon, action_dim) clean buffer action chunk.
+        value_head: ActionValueHead with use_energy_flow=True.
+        hl_gauss_loss: HL-Gauss readout when num_bins > 1, else None.
+        num_bins: distributional bin count of the Q head.
+
+    Returns:
+        (loss, activations_dict, info_dict)
+    """
+    assert getattr(value_head, "use_energy_flow", False), (
+        "compute_actor_loss_with_energy_flow requires value_head.use_energy_flow=True"
+    )
+    B = action.size(0)
+    device = action.device
+
+    sigma_min = value_head.energy_sigma_min
+    sigma_max = value_head.energy_sigma_max
+    sigma_t_max = value_head.energy_sigma_t_max
+    eps = 1e-4
+
+    # Diffusion timestep t ~ U(eps, T).
+    t = torch.rand(B, device=device) * (sigma_t_max - eps) + eps
+    sigma_t = _vp_sigma(t, sigma_min, sigma_max, sigma_t_max)  # (B,)
+    sigma_t_view = sigma_t.view(B, 1, 1)
+
+    # Forward perturbation: a_t = a_0 + σ(t) ε.
+    noise = torch.randn_like(action)
+    a_t = (action + sigma_t_view * noise).detach().requires_grad_(True)
+
+    # Score = ∇_a Q via autograd through the advantage stream.
+    grad = value_head.compute_score(state, a_t, t, hl_gauss_loss, create_graph=True)
+
+    # || σ(t) · ∇_a Q + ε ||² (per-element MSE).
+    diff = sigma_t_view * grad + noise
+    loss = diff.pow(2).mean()
+
+    info_dict = {
+        "actor_loss": loss.item(),
+        "dacer_loss": 0.0,
+        "energy_flow_score_norm": grad.detach().pow(2).mean().sqrt().item(),
+        "energy_flow_sigma_mean": sigma_t.mean().item(),
+    }
+    activations_dict: dict = {}
+
+    return loss, activations_dict, info_dict

--- a/src/vla_streaming_rl/networks/value_head.py
+++ b/src/vla_streaming_rl/networks/value_head.py
@@ -1,11 +1,80 @@
 # SPDX-License-Identifier: MIT
+import math
+
 import torch
 from hl_gauss_pytorch import HLGaussLoss
 from torch import nn
+from torch.nn.utils.parametrizations import spectral_norm
 
 from .blocks import SimbaBlock
 from .image_processor import ImageProcessor
 from .sparse_utils import apply_one_shot_pruning
+
+
+class _MishResidualBlock(nn.Module):
+    """C^2-differentiable residual MLP block used as energy-flow backbone."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.LayerNorm(channels, elementwise_affine=False),
+            nn.Linear(channels, channels),
+            nn.Mish(),
+            nn.Linear(channels, channels),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.net(x)
+
+
+class _EnergyTimeEmbedder(nn.Module):
+    def __init__(self, hidden_size: int, frequency_embedding_size: int = 128) -> None:
+        super().__init__()
+        self.frequency_embedding_size = frequency_embedding_size
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.Mish(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+
+    @staticmethod
+    def timestep_embedding(t: torch.Tensor, dim: int, max_period: int = 10000) -> torch.Tensor:
+        half = dim // 2
+        freqs = torch.exp(
+            -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+        ).to(device=t.device)
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        return self.mlp(self.timestep_embedding(t, self.frequency_embedding_size))
+
+
+def _vp_sigma(
+    t: torch.Tensor | float,
+    sigma_min: float,
+    sigma_max: float,
+    sigma_t_max: float,
+) -> torch.Tensor | float:
+    """Geometric VE noise schedule: sigma(t) = sigma_min^(1 - t/T) * sigma_max^(t/T)."""
+    if isinstance(t, torch.Tensor):
+        return sigma_min ** (1.0 - t / sigma_t_max) * sigma_max ** (t / sigma_t_max)
+    return sigma_min ** (1.0 - t / sigma_t_max) * sigma_max ** (t / sigma_t_max)
+
+
+def _dsigma2_dt(
+    t: torch.Tensor | float,
+    sigma_min: float,
+    sigma_max: float,
+    sigma_t_max: float,
+) -> torch.Tensor | float:
+    """d/dt of sigma(t)^2 for the geometric VE schedule."""
+    log_ratio = math.log(sigma_max) - math.log(sigma_min)
+    sigma2 = _vp_sigma(t, sigma_min, sigma_max, sigma_t_max) ** 2
+    return sigma2 * (2.0 / sigma_t_max) * log_ratio
 
 
 def maybe_update_hl_gauss_range(
@@ -67,7 +136,16 @@ class StateValueHead(nn.Module):
 
 
 class ActionValueHead(nn.Module):
-    """Dueling Architecture: Q(s,a) = V(s) + A(s,a)"""
+    """Dueling Architecture: Q(s,a) = V(s) + A(s,a).
+
+    When ``use_energy_flow=True`` the advantage stream is also conditioned on a
+    diffusion timestep t, uses Mish activations (C^2-differentiable as required
+    by EnergyFlow score matching), and applies spectral normalization to its
+    output linear layer. In that mode Q(s,a,t) plays the role of a soft energy
+    field: its action gradient defines a denoising score, and probability-flow
+    ODE rollouts on that score generate actions (Algorithm 2 of "Recovering
+    Hidden Reward in Diffusion-Based Policies").
+    """
 
     def __init__(
         self,
@@ -78,12 +156,25 @@ class ActionValueHead(nn.Module):
         block_num: int,
         num_bins: int,
         sparsity: float,
+        use_energy_flow: bool,
+        energy_sigma_min: float,
+        energy_sigma_max: float,
+        energy_sigma_t_max: float,
+        energy_ode_steps: int,
+        energy_ode_endpoint: float,
+        energy_time_embed_dim: int,
     ) -> None:
         super().__init__()
         self.horizon = horizon
         self.action_dim = action_dim
         total_action_dim = action_dim * horizon
-        mid_dim = in_channels + total_action_dim
+        self.num_bins = num_bins
+        self.use_energy_flow = use_energy_flow
+        self.energy_sigma_min = energy_sigma_min
+        self.energy_sigma_max = energy_sigma_max
+        self.energy_sigma_t_max = energy_sigma_t_max
+        self.energy_ode_steps = energy_ode_steps
+        self.energy_ode_endpoint = energy_ode_endpoint
 
         # Value stream: V(s) - depends only on state
         self.v_fc_in = nn.Linear(in_channels, hidden_dim)
@@ -91,23 +182,59 @@ class ActionValueHead(nn.Module):
         self.v_norm = nn.LayerNorm(hidden_dim, elementwise_affine=False)
         self.v_fc_out = nn.Linear(hidden_dim, num_bins)
 
-        # Advantage stream: A(s,a) - depends on state and action
-        self.a_fc_in = nn.Linear(mid_dim, hidden_dim)
-        self.a_fc_mid = nn.Sequential(*[SimbaBlock(hidden_dim) for _ in range(block_num)])
+        # Advantage stream: A(s,a[,t])
+        if use_energy_flow:
+            self.t_embedder = _EnergyTimeEmbedder(energy_time_embed_dim)
+            adv_in_dim = in_channels + total_action_dim + energy_time_embed_dim
+            block_cls: type[nn.Module] = _MishResidualBlock
+        else:
+            self.t_embedder = None
+            adv_in_dim = in_channels + total_action_dim
+            block_cls = SimbaBlock
+
+        self.a_fc_in = nn.Linear(adv_in_dim, hidden_dim)
+        self.a_fc_mid = nn.Sequential(*[block_cls(hidden_dim) for _ in range(block_num)])
         self.a_norm = nn.LayerNorm(hidden_dim, elementwise_affine=False)
         self.a_fc_out = nn.Linear(hidden_dim, num_bins)
 
         self.apply(weights_init_)
 
+        # Spectral normalization on the scalar energy readout (paper §C.2).
+        # Apply after weight init since spectral_norm replaces the weight with
+        # a parametrization that cannot be assigned to in-place.
+        if use_energy_flow:
+            self.a_fc_out = spectral_norm(self.a_fc_out)
+
         self.sparse_mask = (
             None if sparsity == 0.0 else apply_one_shot_pruning(self, overall_sparsity=sparsity)
         )
 
-    def forward(self, x: torch.Tensor, a: torch.Tensor) -> dict[str, torch.Tensor]:
+    def _build_advantage_input(
+        self,
+        x: torch.Tensor,
+        a_flat: torch.Tensor,
+        t: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if self.use_energy_flow:
+            assert self.t_embedder is not None
+            if t is None:
+                t = torch.zeros(a_flat.size(0), device=a_flat.device)
+            t_emb = self.t_embedder(t)
+            return torch.cat([x, a_flat, t_emb], dim=1)
+        return torch.cat([x, a_flat], dim=1)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        a: torch.Tensor,
+        t: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
         """
         Args:
             x: state embedding (B, state_dim)
             a: action chunk (B, horizon, action_dim)
+            t: diffusion timestep (B,) or None. Required only when
+                ``use_energy_flow`` is True; ignored otherwise.
         """
         result_dict = {}
         bs = a.size(0)
@@ -119,8 +246,8 @@ class ActionValueHead(nn.Module):
         v = self.v_norm(v)
         v_out = self.v_fc_out(v)  # (B, num_bins)
 
-        # Advantage stream: A(s,a)
-        xa = torch.cat([x, a_flat], dim=1)
+        # Advantage stream: A(s,a[,t])
+        xa = self._build_advantage_input(x, a_flat, t)
         adv = self.a_fc_in(xa)
         adv = self.a_fc_mid(adv)
         adv = self.a_norm(adv)
@@ -134,17 +261,23 @@ class ActionValueHead(nn.Module):
 
         return result_dict
 
-    def get_advantage(self, x: torch.Tensor, a: torch.Tensor) -> dict[str, torch.Tensor]:
+    def get_advantage(
+        self,
+        x: torch.Tensor,
+        a: torch.Tensor,
+        t: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
         """
         Args:
             x: state embedding (B, state_dim)
             a: action chunk (B, horizon, action_dim)
+            t: diffusion timestep (B,) or None.
         """
         result_dict = {}
         bs = a.size(0)
         a_flat = a.view(bs, -1)  # (B, horizon * action_dim)
 
-        xa = torch.cat([x, a_flat], dim=1)
+        xa = self._build_advantage_input(x, a_flat, t)
         adv = self.a_fc_in(xa)
         adv = self.a_fc_mid(adv)
         adv = self.a_norm(adv)
@@ -153,6 +286,81 @@ class ActionValueHead(nn.Module):
         result_dict["output"] = adv_out
 
         return result_dict
+
+    ###########################
+    # Energy-flow extensions  #
+    ###########################
+
+    def _q_scalar(
+        self,
+        x: torch.Tensor,
+        a: torch.Tensor,
+        t: torch.Tensor,
+        hl_gauss_loss: nn.Module | None,
+    ) -> torch.Tensor:
+        """Forward returning Q as a scalar (B,) tensor (differentiable in a)."""
+        # Only the advantage stream depends on a, so it suffices for ∇_a Q.
+        out = self.get_advantage(x, a, t)["output"]  # (B, num_bins) or (B, 1)
+        if self.num_bins > 1:
+            assert hl_gauss_loss is not None
+            return hl_gauss_loss(out)  # (B,)
+        return out.view(-1)
+
+    def compute_score(
+        self,
+        x: torch.Tensor,
+        a: torch.Tensor,
+        t: torch.Tensor,
+        hl_gauss_loss: nn.Module | None,
+        create_graph: bool,
+    ) -> torch.Tensor:
+        """Return ∇_a Q(s, a, t).
+
+        With Q ∝ log π_E (max-entropy), this is the score of the expert action
+        distribution. Works in eval (create_graph=False) and train.
+        """
+        if not a.requires_grad:
+            a = a.detach().requires_grad_(True)
+        with torch.enable_grad():
+            q = self._q_scalar(x, a, t, hl_gauss_loss)
+            grad = torch.autograd.grad(q.sum(), a, create_graph=create_graph)[0]
+        return grad
+
+    def get_action(
+        self,
+        x: torch.Tensor,
+        hl_gauss_loss: nn.Module | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sample action chunks via probability-flow ODE on +∇_a Q.
+
+        Mirrors Algorithm 2 of "Recovering Hidden Reward in Diffusion-Based
+        Policies" with the sign convention E = -Q, so the update direction is
+        +∇_a Q (gradient ascent on Q):
+            a_{k+1} = a_k + (Δt / 2) · d[σ²]/dt|_{t_k} · ∇_a Q(a_k, s, t_k)
+        Returns ``(action, dummy_log_p)`` to match the policy_head interface.
+        """
+        assert self.use_energy_flow, "ActionValueHead.get_action requires use_energy_flow=True"
+        bs = x.size(0)
+        device = x.device
+        T = self.energy_sigma_t_max
+        gamma = self.energy_ode_endpoint
+        K = self.energy_ode_steps
+        sigma_T = float(
+            _vp_sigma(T, self.energy_sigma_min, self.energy_sigma_max, T)
+        )
+        a = sigma_T * torch.randn(bs, self.horizon, self.action_dim, device=device)
+        dt = (T - gamma) / K
+        for k in range(K):
+            t_val = T - k * dt
+            t_tensor = torch.full((bs,), t_val, device=device)
+            grad = self.compute_score(x, a, t_tensor, hl_gauss_loss, create_graph=False)
+            dsig2 = float(
+                _dsigma2_dt(t_val, self.energy_sigma_min, self.energy_sigma_max, T)
+            )
+            a = a.detach() + dt * 0.5 * dsig2 * grad.detach()
+        a = torch.tanh(a)
+        dummy_log_p = torch.zeros((bs, 1), device=device)
+        return a, dummy_log_p
 
 
 class SeparateCritic(nn.Module):

--- a/src/vla_streaming_rl/networks/vlm_actor_critic_with_action_value.py
+++ b/src/vla_streaming_rl/networks/vlm_actor_critic_with_action_value.py
@@ -187,7 +187,7 @@ class VLMActorCriticWithActionValue(nn.Module):
             denoising_steps=denoising_steps,
         )
 
-        # Critic: Q(state, action)
+        # Critic: Q(state, action). VLM path does not use energy_flow.
         self.value_head = ActionValueHead(
             in_channels=state_dim,
             action_dim=self.action_dim,
@@ -196,6 +196,13 @@ class VLMActorCriticWithActionValue(nn.Module):
             block_num=critic_block_num,
             num_bins=num_bins,
             sparsity=sparsity,
+            use_energy_flow=False,
+            energy_sigma_min=0.01,
+            energy_sigma_max=1.0,
+            energy_sigma_t_max=1.0,
+            energy_ode_steps=20,
+            energy_ode_endpoint=0.001,
+            energy_time_embed_dim=128,
         )
 
         self.prediction_head = StatePredictionHead(


### PR DESCRIPTION
Actor-Criticネットワークを単一にできるのではないかと考えたが、それだと分散保存型での拡散モデルのノイズスケジュールを使う必要があり、One-Step Diffusion系統への発展性が乏しいように感じられた。

現状の理解では、スコア予測（解釈の一つにはランジュバンモンテカルロ法によるMCMCがある）と、Flow Matching系が志向している決定的関数（対応付け）との間には食い合わせが悪いところがあり、上手く解消する方法がわかっていない。

ダメそうということをメモするためにPRだけ作ってすぐCloseする。